### PR TITLE
Rebuild on updated gnutls (part of XENSERVER-2025-HCP-1846)

### DIFF
--- a/SPECS/swtpm.spec
+++ b/SPECS/swtpm.spec
@@ -7,7 +7,7 @@
 Summary: TPM Emulator
 Name:           swtpm
 Version:        0.7.3
-Release: %{?xsrel}.1%{?dist}
+Release: %{?xsrel}.2%{?dist}
 License:        BSD
 Source0: swtpm-0.7.3.tar.gz
 Patch0: swtpm_setup-Configure-swtpm-to-log-to-stdout-err-if-.patch
@@ -167,6 +167,9 @@ cp %{SOURCE1} %{buildroot}/%{_sysconfdir}/ssl/
 %{?_cov_results_package}
 
 %changelog
+* Mon Mar 16 2026 Philippe Coval <philippe.coval@vates.tech> - 0.7.3-12.2
+- Rebuild on updated gnutls
+
 * Mon Jan 26 2026 Philippe Coval <philippe.coval@vates.tech> - 0.7.3-12.1
 - Rebuild on openssl-3
 


### PR DESCRIPTION
Rebuild on updated gnutls 

Depends on:

- https://github.com/xcp-ng-rpms/gnutls/pull/2

Motivated by:

- https://github.com/xcp-ng-rpms/samba/pull/5